### PR TITLE
Replacing imports with forward references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ profile
 *.moved-aside
 # Desktop Servies
 .DS_Store
+.idea

--- a/Mantle/MTLXMLAdapter.h
+++ b/Mantle/MTLXMLAdapter.h
@@ -7,9 +7,9 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "DDXML.h"
-#import "DDXMLNode.h"
 
+@class DDXMLNode;
+@class DDXMLElement;
 @class MTLModel;
 
 @protocol MTLXMLSerializing

--- a/Mantle/NSValueTransformer+MTLXMLTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLXMLTransformerAdditions.m
@@ -10,13 +10,13 @@
 #import "MTLModel.h"
 #import "MTLValueTransformer.h"
 #import "MTLXMLAdapter.h"
-
+#import "DDXML.h"
 
 @implementation NSValueTransformer (MTLXMLTransformerAdditions)
 
 + (NSDateFormatter *)dateFormatter
 {
-    static NSDateFormatter* _dateFormatter;
+    static NSDateFormatter *_dateFormatter;
     if (!_dateFormatter)
     {
         _dateFormatter = [NSDateFormatter new];
@@ -27,7 +27,7 @@
     return _dateFormatter;
 }
 
-+ (NSValueTransformer *)mtl_XMLTransformerForDateWithFormat:(NSString*)dateFormat {
++ (NSValueTransformer *)mtl_XMLTransformerForDateWithFormat:(NSString *)dateFormat {
 	return [MTLValueTransformer
             reversibleTransformerWithForwardBlock:^id(NSArray *nodes) {
                 if (nodes == nil || nodes.count == 0) return nil;

--- a/Mantle/NSValueTransformer+MTLXMLTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLXMLTransformerAdditions.m
@@ -14,15 +14,14 @@
 
 @implementation NSValueTransformer (MTLXMLTransformerAdditions)
 
-+ (NSDateFormatter *)dateFormatter
-{
++ (NSDateFormatter *)dateFormatter {
     NSMutableDictionary *dictionary = [[NSThread currentThread] threadDictionary];
-    NSDateFormatter *dateFormatter = [dictionary objectForKey:@"MTLDateFormatter"];
+    NSDateFormatter *dateFormatter = dictionary[@"MTLDateFormatter"];
     if (!dateFormatter) {
-        dateFormatter = [[[NSDateFormatter alloc] init] autorelease];
-        [dateFormatter setDateStyle:NSDateFormatterFullStyle];
-        [dateFormatter setTimeStyle:NSDateFormatterFullStyle];
-        [dictionary setObject:dateFormatter forKey:@"MTLDateFormatter"];
+        dateFormatter = [[NSDateFormatter alloc] init];
+        dateFormatter.dateStyle = NSDateFormatterFullStyle;
+        dateFormatter.timeStyle = NSDateFormatterFullStyle;
+        dictionary[@"MTLDateFormatter"] = dateFormatter;
     }
 
     return dateFormatter;

--- a/Mantle/NSValueTransformer+MTLXMLTransformerAdditions.m
+++ b/Mantle/NSValueTransformer+MTLXMLTransformerAdditions.m
@@ -16,15 +16,16 @@
 
 + (NSDateFormatter *)dateFormatter
 {
-    static NSDateFormatter *_dateFormatter;
-    if (!_dateFormatter)
-    {
-        _dateFormatter = [NSDateFormatter new];
-        [_dateFormatter setDateStyle:NSDateFormatterFullStyle];
-        [_dateFormatter setTimeStyle:NSDateFormatterFullStyle];
+    NSMutableDictionary *dictionary = [[NSThread currentThread] threadDictionary];
+    NSDateFormatter *dateFormatter = [dictionary objectForKey:@"MTLDateFormatter"];
+    if (!dateFormatter) {
+        dateFormatter = [[[NSDateFormatter alloc] init] autorelease];
+        [dateFormatter setDateStyle:NSDateFormatterFullStyle];
+        [dateFormatter setTimeStyle:NSDateFormatterFullStyle];
+        [dictionary setObject:dateFormatter forKey:@"MTLDateFormatter"];
     }
-    
-    return _dateFormatter;
+
+    return dateFormatter;
 }
 
 + (NSValueTransformer *)mtl_XMLTransformerForDateWithFormat:(NSString *)dateFormat {
@@ -149,7 +150,7 @@
             ];
 }
 
-+ (NSValueTransformer *)mtl_XMLNonUniformObjectArrayTransformerWithModelClass:(Class)modelClass {
++ (NSValueTransformer *)mtl_XMLNonUniformObjectArrayTransformerWithModelClass:(Class<MTLXMLSerializing>)modelClass {
     
 	return [MTLValueTransformer
             reversibleTransformerWithForwardBlock:^ id (NSArray *nodes) {

--- a/MantleXMLAdapter.podspec
+++ b/MantleXMLAdapter.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "MantleXMLAdapter"
   s.platform     = :ios, "5.0"
-  s.version      = "0.2.2"
+  s.version      = "0.2.5"
   s.summary      = "MantleXMLAdapter adds support to Mantle to create MTLModel objects from xml documents and (optionally) from models into xml documents."
   s.homepage     = "https://github.com/mbaranowski/MantleXMLAdapter"
   s.license      = "MIT"

--- a/MantleXMLAdapter.podspec
+++ b/MantleXMLAdapter.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/mbaranowski/MantleXMLAdapter"
   s.license      = "MIT"
   s.authors      = { "Matthew Baranowski" => "matt.baranowski@willowtreeapps.com" }
-  s.source       = { :git => "https://github.com/mbaranowski/MantleXMLAdapter.git", :tag => '0.2.2' }
+  s.source       = { :git => "https://github.com/mbaranowski/MantleXMLAdapter.git", :tag => '0.2.5' }
   s.source_files = 'Mantle/MTLXMLAdapter.{h,m}', 'Mantle/NSValueTransformer+MTLXMLTransformerAdditions.{h,m}'
   s.dependency  'KissXML'
   s.dependency  'Mantle'


### PR DESCRIPTION
Hi, in order to allow MantleXMLAdapter to be imported flawlessly as a dependency into other pods, I replaced some imports with forward declarations.

Keep up the good work,
Simone 
